### PR TITLE
[c1tenth-driver-wrappers] set the required node names correctly

### DIFF
--- a/bno055_ros2_driver_wrapper/launch/bno055_ros2_driver_wrapper.launch.py
+++ b/bno055_ros2_driver_wrapper/launch/bno055_ros2_driver_wrapper.launch.py
@@ -26,7 +26,7 @@ def generate_launch_description():
 
   # Note that the name must match the param file.
   driver_node = Node(
-          name='bno055',
+          name='bno055_ros2_driver',
           package='bno055',
           executable='bno055',
           parameters=[DRIVER_PARAM_FILE],
@@ -36,7 +36,7 @@ def generate_launch_description():
 
   # If we want a regular node (composable:=false) then this is run.
   wrapper_node = Node(
-          name='bno055_driver_wrapper_node',
+          name='bno055_ros2_driver_wrapper',
           package='bno055_ros2_driver_wrapper',
           executable='bno055_driver_wrapper_node',
           parameters=[WRAPPER_PARAM_FILE],
@@ -54,7 +54,7 @@ def generate_launch_description():
           condition=IfCondition(LaunchConfiguration("composable")),
           composable_node_descriptions=[
               ComposableNode(
-                  name='bno055_ros2_driver_wrapper_composable_node',
+                  name='bno055_ros2_driver_wrapper',
                   package='bno055_ros2_driver_wrapper',
                   plugin='bno055_ros2_driver_wrapper::ComposableNode',
                   parameters=[WRAPPER_PARAM_FILE],

--- a/joy_ros2_driver_wrapper/launch/joy_ros2_driver_wrapper.launch.py
+++ b/joy_ros2_driver_wrapper/launch/joy_ros2_driver_wrapper.launch.py
@@ -27,6 +27,7 @@ def generate_launch_description():
   # Publishes:
   # + input/joy                      (sensor_msgs::msg::Joy)
   driver_node = Node(
+      name='joy_ros2_driver',
       package='joy_linux',
       executable='joy_linux_node',
       output='screen',
@@ -40,7 +41,7 @@ def generate_launch_description():
   # + /vehicle/engage                 (std_msgs::msg::Bool)
   # + /vehicle_cmd                    (autoware_msgs::msg::VehicleCmd)
   wrapper_node = Node(
-          name='joy_driver_wrapper_node',
+          name='joy_ros2_driver_wrapper',
           package='joy_ros2_driver_wrapper',
           executable='joy_driver_wrapper_node',
           parameters=[WRAPPER_PARAM_FILE],
@@ -56,7 +57,7 @@ def generate_launch_description():
           condition=IfCondition(LaunchConfiguration("composable")),
           composable_node_descriptions=[
               ComposableNode(
-                  name='joy_ros2_driver_wrapper_composable_node',
+                  name='joy_ros2_driver_wrapper',
                   package='joy_ros2_driver_wrapper',
                   plugin='joy_ros2_driver_wrapper::ComposableNode',
                   parameters=[WRAPPER_PARAM_FILE],

--- a/joy_ros2_driver_wrapper/src/ComposableNode.cpp
+++ b/joy_ros2_driver_wrapper/src/ComposableNode.cpp
@@ -102,8 +102,8 @@ namespace joy_ros2_driver_wrapper
             std::bind(&ComposableNode::joy_callback, this, std::placeholders::_1));
         
         // Add publishers for the control output
-        vehicle_cmd_pub_ = create_publisher<autoware_msgs::msg::VehicleCmd>("/vehicle_cmd", 10);
-        engage_pub_ = create_publisher<std_msgs::msg::Bool>("/vehicle/engage", 10);
+        vehicle_cmd_pub_ = create_publisher<autoware_msgs::msg::VehicleCmd>("controller/vehicle_cmd", 10);
+        engage_pub_ = create_publisher<std_msgs::msg::Bool>("vehicle/engage", 10);
 
         return CallbackReturn::SUCCESS;
     }

--- a/sllidar_ros2_driver_wrapper/launch/sllidar_ros2_driver_wrapper.launch.py
+++ b/sllidar_ros2_driver_wrapper/launch/sllidar_ros2_driver_wrapper.launch.py
@@ -26,25 +26,25 @@ def generate_launch_description():
 
   # Note that the name must match the param file.
   driver_node = Node(
+    name='sllidar_ros2_driver',
     package='sllidar_ros2',
     executable='sllidar_node',
-    name='sllidar_node',
     namespace='lidar',
     parameters=[DRIVER_PARAM_FILE],
     output='screen')
 
   # Note that the name must match the param file.
   converter_node = Node(
+    name='sllidar_ros2_converter',
     package='sllidar_ros2_driver_wrapper',
     executable='lidar_scan_to_point_cloud2',
-    name='sllidar_node',
     namespace='lidar',
     parameters=[DRIVER_PARAM_FILE],
     output='screen')
 
   # If we want a regular node (composable:=false) then this is run.
   wrapper_node = Node(
-    name='sllidar_driver_wrapper_node',
+    name='sllidar_ros2_driver_wrapper',
     package='sllidar_ros2_driver_wrapper',
     executable='sllidar_driver_wrapper_node',
     parameters=[WRAPPER_PARAM_FILE],
@@ -54,14 +54,14 @@ def generate_launch_description():
 
   # If we want a composable node (composable:=true) then this is run.
   wrapper_composable_node = ComposableNodeContainer(
-    name='sllidar_driver_wrapper_node',
+    name='sllidar_driver_wrapper_container',
     package='carma_ros2_utils',
     executable='carma_component_container_mt',
     namespace='lidar',
     condition=IfCondition(LaunchConfiguration("composable")),
     composable_node_descriptions=[
       ComposableNode(
-        name='sllidar_ros2_driver_wrapper_composable_node',
+        name='sllidar_ros2_driver_wrapper',
         package='sllidar_ros2_driver_wrapper',
         plugin='sllidar_ros2_driver_wrapper::ComposableNode',
         parameters=[WRAPPER_PARAM_FILE],

--- a/vesc_ros2_driver_wrapper/launch/vesc_ros2_driver_wrapper.launch.py
+++ b/vesc_ros2_driver_wrapper/launch/vesc_ros2_driver_wrapper.launch.py
@@ -41,9 +41,9 @@ def generate_launch_description():
   # + vesc/sensors/imu/raw                  (sensor_msgs::msg::Imu)
   # + vesc/sensors/servo_position_command   (std_msgs::msg::Float64)
   driver_node = Node(
+      name='vesc_ros2_driver',
       package='vesc_driver',
       executable='vesc_driver_node',
-      name='vesc_driver_node',
       namespace='vesc',
       output='screen',
       parameters=[DRIVER_PARAM_FILE]
@@ -60,7 +60,7 @@ def generate_launch_description():
   # + controller/vehicle_status             (autoware_msgs::msg::VehicleStatus)
   # + controller/vehicle/twist              (geometry_msgs::msg::TwistStamped)
   wrapper_node = Node(
-          name='vesc_ros2_driver_wrapper_node',
+          name='vesc_ros2_driver_wrapper',
           package='vesc_ros2_driver_wrapper',
           executable='vesc_driver_wrapper_node',
           parameters=[WRAPPER_PARAM_FILE],
@@ -76,7 +76,7 @@ def generate_launch_description():
           condition=IfCondition(LaunchConfiguration("composable")),
           composable_node_descriptions=[
               ComposableNode(
-                  name='vesc_ros2_driver_wrapper_composable_node',
+                  name='vesc_ros2_driver_wrapper',
                   package='vesc_ros2_driver_wrapper',
                   plugin='vesc_ros2_driver_wrapper::ComposableNode',
                   parameters=[WRAPPER_PARAM_FILE],

--- a/vesc_ros2_driver_wrapper/src/ComposableNode.cpp
+++ b/vesc_ros2_driver_wrapper/src/ComposableNode.cpp
@@ -161,9 +161,9 @@ namespace vesc_ros2_driver_wrapper
             std::bind(&ComposableNode::vesc_state_callback, this, std::placeholders::_1));
         vesc_servo_sub_ = create_subscription<std_msgs::msg::Float64>("vesc/sensors/servo_position_command", 10,
             std::bind(&ComposableNode::vesc_servo_callback, this, std::placeholders::_1));
-        vehicle_cmd_sub_ = create_subscription<autoware_msgs::msg::VehicleCmd>("/vehicle_cmd", 10,
+        vehicle_cmd_sub_ = create_subscription<autoware_msgs::msg::VehicleCmd>("controller/vehicle_cmd", 10,
             std::bind(&ComposableNode::vehicle_cmd_callback, this, std::placeholders::_1));   
-        engage_sub_ = create_subscription<std_msgs::msg::Bool>("/vehicle/engage", 10,
+        engage_sub_ = create_subscription<std_msgs::msg::Bool>("vehicle/engage", 10,
             std::bind(&ComposableNode::engage_callback, this, std::placeholders::_1));
 
         return CallbackReturn::SUCCESS;


### PR DESCRIPTION
Determined that there are locations in the carma-config YAML files where node names are hard-coded as being expected. Update these names to their actual values.